### PR TITLE
feat: implement manifest-based DataFrameIOManager

### DIFF
--- a/src/dagster_covid19/resources/dataframe_io_manager.py
+++ b/src/dagster_covid19/resources/dataframe_io_manager.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import json
 import os
 from collections.abc import Iterator
+from json import JSONDecodeError
 from pathlib import Path
+from typing import Optional, Union
 
 import pandas as pd
 from dagster import InputContext, OutputContext, UPathIOManager
-from pydantic import BaseModel
+from pydantic import BaseModel, parse_obj_as, ValidationError
 from upath import UPath
 
 from dagster_covid19.config.path import get_tmp_dir
@@ -23,13 +26,23 @@ class DataFrameIOManagerConfig(BaseModel):
         return DataFrameIOManagerConfig(base_path=df_path)
 
 
+class DataFrameIOManagerManifestV1(BaseModel):
+    run_id: Optional[str]
+    files_list: list[str] = []
+
+
+class DataFrameIOManagerVersionManifest(BaseModel):
+    version: int = 1
+    content: DataFrameIOManagerManifestV1
+
+
 class DataFrameIOManager(UPathIOManager):
     def __init__(self, config: DataFrameIOManagerConfig):
         super().__init__(UPath(config.base_path))
 
     @staticmethod
-    def _file_name(count: int, asset_path: UPath) -> UPath:
-        return asset_path / f"{count}.parquet"
+    def _manifest_name(asset_path: UPath) -> UPath:
+        return asset_path / "manifest.json"
 
     def dump_to_path(
         self, context: OutputContext, obj: Iterator[pd.DataFrame], path: UPath
@@ -40,10 +53,63 @@ class DataFrameIOManager(UPathIOManager):
         :param obj: obj to write to parquet file
         :param path: directory to write to
         """
-        context.log.info("Saving output of %s to %s", context.asset_key, path)
+        # Every run we write the output into a different path
+        run_id_path = path / context.run_id
+        if not run_id_path.exists():
+            run_id_path.mkdir(parents=True)
+        context.log.info("Saving output of %s to %s", context.asset_key, run_id_path)
+        new_files = []
         for count, element in enumerate(obj):
-            parquet_file = self._file_name(count, path)
+            parquet_file = run_id_path / f"{count}.parquet"
             element.to_parquet(parquet_file)
+            new_files.append(str(parquet_file))
+
+        self._update_manifest(context, new_files, path)
+
+    def _read_manifest(
+        self, context: Union[InputContext, OutputContext], path: UPath
+    ) -> DataFrameIOManagerManifestV1:
+        manifest_name = self._manifest_name(path)
+        context.log.info("Reading manifest [path=%s]", manifest_name)
+        with open(manifest_name, "rb") as manifest_in:
+            config_dict = json.load(manifest_in)
+        return parse_obj_as(DataFrameIOManagerVersionManifest, config_dict).content
+
+    def _update_manifest(
+        self, context: OutputContext, new_files: list[str], path: UPath
+    ) -> None:
+        # Update manifest to point to new set of files
+        # Read the list of old files
+        try:
+            old_manifest = self._read_manifest(context, path)
+        except (FileNotFoundError, JSONDecodeError, ValidationError):
+            context.log.exception("Exception reading old manifest. Skipping")
+            old_manifest = None
+
+        # Write new manifest
+        manifest_name = self._manifest_name(path)
+        context.log.info("Updating manifest %s", manifest_name)
+        manifest_data = DataFrameIOManagerVersionManifest(
+            content=DataFrameIOManagerManifestV1(
+                run_id=context.run_id, files_list=new_files
+            )
+        )
+        # Write manifest to a tempfile because
+        # json.dump can mangle the output in case of exception
+        tmp_manifest = manifest_name.with_suffix(".tmp")
+        with open(tmp_manifest, "w") as manifest_out:
+            json.dump(manifest_data.dict(), manifest_out)
+        # Swap tmp manifest into place
+        tmp_manifest.replace(manifest_name)
+        # Remove old files from previous run_id
+        if old_manifest is not None:
+            run_id_path = path / old_manifest.run_id
+            context.log.info(
+                "Removing old files from previous runs. [path=%s]", run_id_path
+            )
+            for f in old_manifest.files_list:
+                UPath(f).unlink(missing_ok=True)
+            run_id_path.rmdir()
 
     def load_from_path(
         self, context: InputContext, path: UPath
@@ -55,10 +121,10 @@ class DataFrameIOManager(UPathIOManager):
         :return: dataframe of the parquet files
         """
         context.log.info("Loading input %s from %s", context.asset_key, path)
+        old_manifest = self._read_manifest(context, path)
 
         def parquet_df_gen():
-            for count, element in enumerate(os.listdir(path)):
-                input_path = self._file_name(count, path)
+            for input_path in old_manifest.files_list:
                 par_df = pd.read_parquet(input_path)
                 yield par_df
 

--- a/tests/dagster_covid19_tests/resources/test_dataframe_io_manager.py
+++ b/tests/dagster_covid19_tests/resources/test_dataframe_io_manager.py
@@ -3,6 +3,7 @@
 import pandas as pd
 from dagster import AssetKey, build_input_context, build_output_context
 
+from dagster_covid19.config.datatypes import DataFrameIterator
 from dagster_covid19.resources import DataFrameIOManager, DataFrameIOManagerConfig
 
 from pandas.testing import assert_frame_equal
@@ -15,9 +16,20 @@ def should__save_and_load_dataframe_iterator():
     df_2 = pd.DataFrame({"col1": [4, 5, 6, 7], "col2": [-4, -5, -6, -7]})
     output_df = [df_1, df_2]
     output_context = build_output_context(
-        name="result", asset_key=AssetKey(["test_asset"])
+        name="result",
+        asset_key=AssetKey(["test_asset"]),
+        dagster_type=DataFrameIterator,
+        run_id="run_1",
     )
     manager.handle_output(output_context, output_df)
+    # Write twice to check for both writing and updating
+    output_context_2 = build_output_context(
+        name="result",
+        asset_key=AssetKey(["test_asset"]),
+        dagster_type=DataFrameIterator,
+        run_id="run_2",
+    )
+    manager.handle_output(output_context_2, output_df)
 
     input_context = build_input_context(asset_key=AssetKey(["test_asset"]))
     input_df = manager.load_input(input_context)


### PR DESCRIPTION
* New data are written into a separate directory and only swap into place when all the data has been successfully written. This is done atomically using a manifest file replace operation.
* Data are read using the manifest file to avoid using listing operation.